### PR TITLE
 Web-worker wrapper: Add type def for postMessage to allow strict compiler mode

### DIFF
--- a/src/utils/web-worker.ts
+++ b/src/utils/web-worker.ts
@@ -4,6 +4,13 @@ import { Mp4Demuxer } from '../demuxer/mp4/mp4-demuxer';
 import { MpegTSDemuxer } from '../demuxer/ts/mpegts-demuxer';
 import { WebMDemuxer } from '../demuxer/webm/webm-demuxer';
 
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage
+ */
+type WebWorkerPostMessageFunc = (message: any, transferList?: Array<any>) => void;
+
+declare const postMessage: WebWorkerPostMessageFunc;
+
 export class WebWorker {
     public static onMessage = ((event) => {
         if (event.data) {


### PR DESCRIPTION
Otherwise, the compiler actually thinks this is the `Window.postMessage` method which has a different purpose and signature, and thus complains about the missing second mandatory argument of the latter. (see https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)